### PR TITLE
Removed usage of JavaConversions

### DIFF
--- a/connector/src/main/java/tech/ydb/spark/connector/impl/YdbConnector.java
+++ b/connector/src/main/java/tech/ydb/spark/connector/impl/YdbConnector.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import tech.ydb.auth.TokenAuthProvider;
 import tech.ydb.auth.iam.CloudAuthHelper;
 import tech.ydb.auth.iam.CloudAuthIdentity;
 import tech.ydb.core.auth.StaticCredentials;
@@ -136,9 +137,7 @@ public class YdbConnector extends YdbOptions implements AutoCloseable {
                 break;
             case TOKEN:
                 final String authToken = props.get(AUTH_TOKEN);
-                builder = builder.withAuthProvider((opt) -> {
-                    return CloudAuthIdentity.iamTokenIdentity(authToken);
-                });
+                builder = builder.withAuthProvider(new TokenAuthProvider(authToken));
                 break;
             case NONE:
                 break;

--- a/connector/src/test/java/tech/ydb/spark/connector/integration/IntegrationTest.java
+++ b/connector/src/test/java/tech/ydb/spark/connector/integration/IntegrationTest.java
@@ -33,7 +33,7 @@ public class IntegrationTest {
     @ClassRule
     public static final YdbHelperRule YDB = new YdbHelperRule();
 
-    public static final String TEST_TABLE = "test_table";
+    public static final String TEST_TABLE = "spark_test_table";
 
     private static GrpcTransport transport;
     private static TableClient tableClient;

--- a/pom.xml
+++ b/pom.xml
@@ -121,14 +121,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.2</version>
-                    <configuration>
-                        <!-- Hide warnings on JDK later 8 -->
-                        <argLine>
-                            @{argLine}
-                            --add-opens java.base/java.nio=ALL-UNNAMED
-                            --add-opens java.base/java.net=ALL-UNNAMED
-                        </argLine>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -241,6 +233,10 @@
             <activation>
                 <jdk>[9</jdk>
             </activation>
+            <properties>
+                <!-- Hide warnings on JDK later 8 -->
+                <argLine>--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</argLine>
+            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
JavaConversions has different API in Scala 2.13, so it's better do not use it for support both Scala versions 